### PR TITLE
[client-python] fixing session.auth after api change

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -164,7 +164,8 @@ class OpenCTIApiClient:
         }
 
         if auth is not None:
-            self.session = requests.session(auth=auth)
+            self.session = requests.session()
+            self.session.auth = auth
         else:
             self.session = requests.session()
 


### PR DESCRIPTION




<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* <img width="450" alt="image" src="https://github.com/sean0427/client-python/assets/16319704/d41902e9-bada-4efd-81b0-8c84657070c7">

* requests.session(auth=auth) is not working after API change https://requests.readthedocs.io/en/latest/api/#api-changes

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
